### PR TITLE
Fixed escaped html in link_to

### DIFF
--- a/lib/simple_navigation/rendering/renderer/bootstrap.rb
+++ b/lib/simple_navigation/rendering/renderer/bootstrap.rb
@@ -42,7 +42,7 @@ module SimpleNavigation
           item.html_options = item_options
           link << content_tag(:b, '', :class => 'caret')
         end
-        link_to(link.join(" "), url, options_for(item))
+        link_to(link.join(" ").html_safe, url, options_for(item))
       end
     end
   end


### PR DESCRIPTION
When menu was rendered, `<b class="caret"><b>` was escaped and added as text to dropdown menu links. I fixed it.
